### PR TITLE
Use config file for credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ account.properties
 
 .idea/
 *.iml
+src/main/resources/config.toml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 target
 
 account.properties
+
+.idea/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,11 @@
 			<artifactId>hamcrest-all</artifactId>
 			<version>1.3</version>
 		</dependency>
+		<dependency>
+			<groupId>com.moandjiezana.toml</groupId>
+			<artifactId>toml4j</artifactId>
+			<version>0.7.2</version>
+		</dependency>
 	</dependencies>
 
 	<distributionManagement>

--- a/src/main/java/com/sipgate/siptest/Config.java
+++ b/src/main/java/com/sipgate/siptest/Config.java
@@ -6,7 +6,4 @@ public class Config {
 
     public String number;
 
-    public Config(String configFile) {
-
-    }
 }

--- a/src/main/java/com/sipgate/siptest/Config.java
+++ b/src/main/java/com/sipgate/siptest/Config.java
@@ -1,0 +1,12 @@
+package com.sipgate.siptest;
+
+public class Config {
+
+    public String password;
+
+    public String number;
+
+    public Config(String configFile) {
+
+    }
+}

--- a/src/main/java/com/sipgate/siptest/Main.java
+++ b/src/main/java/com/sipgate/siptest/Main.java
@@ -18,7 +18,7 @@ public class Main {
 	private static final String NUMBER_0 = "020387844335";
 
 	public static void main(String[] args) {
-		Config config = getConfig();
+		Config config = getConfig("config.toml");
 
 		final SipgateUserAgent userAgent = SipgateUserAgent
 				.newBuilder()
@@ -51,12 +51,12 @@ public class Main {
 	 *
 	 * @return Config instance initialized with contents from config.toml
 	 */
-	private static Config getConfig() {
+	public static Config getConfig(String fileName) {
 		String filePath = "";
 
 		try {
 			filePath = Main.class.getClassLoader().
-					getResource("config.toml").
+					getResource(fileName).
 					getFile();
 		} catch (NullPointerException e) {
 			LOGGER.error("Could not find config.toml", e);

--- a/src/main/java/com/sipgate/siptest/Main.java
+++ b/src/main/java/com/sipgate/siptest/Main.java
@@ -18,7 +18,7 @@ public class Main {
 	private static final String NUMBER_0 = "020387844335";
 
 	public static void main(String[] args) {
-		Config config = getConfig("config.toml");
+		Config config = getConfig("config.toml", true);
 
 		final SipgateUserAgent userAgent = SipgateUserAgent
 				.newBuilder()
@@ -51,19 +51,24 @@ public class Main {
 	 *
 	 * @return Config instance initialized with contents from config.toml
 	 */
-	public static Config getConfig(String fileName) {
+	public static Config getConfig(String fileName, boolean fromResource) {
+		File configFile;
 		String filePath = "";
 
-		try {
-			filePath = Main.class.getClassLoader().
-					getResource(fileName).
-					getFile();
-		} catch (NullPointerException e) {
-			LOGGER.error("Could not find config.toml", e);
-			System.exit(-1);
+		if (fromResource) {
+			try {
+				filePath = Main.class.getClassLoader().
+						getResource(fileName).
+						getFile();
+			} catch (NullPointerException e) {
+				LOGGER.error("Could not find config.toml", e);
+				System.exit(-1);
+			}
+		} else {
+			filePath = fileName;
 		}
 
-		File configFile = new File(filePath);
+		configFile = new File(filePath);
 		return new Toml().read(configFile).to(Config.class);
 	}
 }

--- a/src/main/java/com/sipgate/siptest/Main.java
+++ b/src/main/java/com/sipgate/siptest/Main.java
@@ -2,8 +2,11 @@ package com.sipgate.siptest;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
+import com.moandjiezana.toml.Toml;
 import com.sipgate.type.extension.E;
 import com.sipgate.type.extension.Extension;
+
+import java.io.File;
 import java.nio.file.Paths;
 import org.slf4j.Logger;
 
@@ -12,14 +15,15 @@ public class Main {
 	private static final Logger LOGGER = getLogger(Main.class);
 
 	private static final E EXTENSION_0 = (E) Extension.parse("2477148e0").get();
-	private static final String PASSWORD_0 = "W6oaVgRhdY4H";
 	private static final String NUMBER_0 = "020387844335";
 
 	public static void main(String[] args) {
+		Config config = getConfig();
+
 		final SipgateUserAgent userAgent = SipgateUserAgent
 				.newBuilder()
 				.forExtension(EXTENSION_0)
-				.withSecret(PASSWORD_0)
+				.withSecret(config.password)
 				.withName("Caller")
 				.withAudioOutput(Paths.get("/tmp/audio.out"))
 				.build();
@@ -40,5 +44,26 @@ public class Main {
 		LOGGER.info("Registering");
 
 		userAgent.register();
+	}
+
+	/**
+	 * Load config.toml configuration file and create new Config instance
+	 *
+	 * @return Config instance initialized with contents from config.toml
+	 */
+	private static Config getConfig() {
+		String filePath = "";
+
+		try {
+			filePath = Main.class.getClassLoader().
+					getResource("config.toml").
+					getFile();
+		} catch (NullPointerException e) {
+			LOGGER.error("Could not find config.toml", e);
+			System.exit(-1);
+		}
+
+		File configFile = new File(filePath);
+		return new Toml().read(configFile).to(Config.class);
 	}
 }

--- a/src/main/resources/config.toml.example
+++ b/src/main/resources/config.toml.example
@@ -1,0 +1,2 @@
+password = "THIS_GOT_TO_BE_SECURE"
+number = "021100000000"

--- a/src/test/java/com/sipgate/siptest/MainTest.java
+++ b/src/test/java/com/sipgate/siptest/MainTest.java
@@ -1,0 +1,33 @@
+package com.sipgate.siptest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.PrintWriter;
+
+import static org.junit.Assert.*;
+
+public class MainTest {
+
+    @Test
+    public void configurationFileGotAPassword() {
+        Config config = Main.getConfig("/tmp/test.toml", false);
+
+        assertEquals("s1pGAt3r0cK5", config.password);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        PrintWriter writer = new PrintWriter("/tmp/test.toml", "UTF-8");
+        writer.println("password = 's1pGAt3r0cK5'");
+        writer.close();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        File tempTestToml = new File("/tmp/test.toml");
+        tempTestToml.delete();
+    }
+}


### PR DESCRIPTION
While looking and the code I stumbled upon hardcoded credentials in the Main class.
This triggered me kinda...
...so I've just implemented a very simple yet easily extensible configuration mechanism based on TOML.

Just copy the config.toml.example to config.toml or provide a custom config file at the commandline (as the first argument after the program name) in order to use it.

I wrote a small test aswell especially for the password-case.